### PR TITLE
Fixed copying of product value.

### DIFF
--- a/APM-Final/src/app/products/product-edit/product-edit.component.ts
+++ b/APM-Final/src/app/products/product-edit/product-edit.component.ts
@@ -30,6 +30,7 @@ export class ProductEditComponent implements OnInit {
     this.currentProduct = value;
     // Clone the object to retain a copy
     this.originalProduct = value ? { ...value } : null;
+    if (!!value.tags) this.originalProduct.tags = [ ...value.tags ]; // clone the product tags
   }
 
   constructor(private productService: ProductService,


### PR DESCRIPTION
Shallow copy of the product makes original and current values
to point to the same tags array, which prevents correct detection
of the form change in some use-cases, e.g. when a tag is removed
and the user is navigating away.